### PR TITLE
Changes Login background color

### DIFF
--- a/src/modules/Login/Login.tsx
+++ b/src/modules/Login/Login.tsx
@@ -87,7 +87,7 @@ export const Login = () => {
     };
 
     return (
-        <div data-test-login-form className="grid place-items-center h-screen bg-palette-neutral-bg-default login-bg">
+        <div data-test-login-form className="grid place-items-center h-screen bg-neutral-30 login-bg">
             <div className="w-[600px] min-h-[740px] flex flex-col justify-start shadow-overlay rounded-3xl py-8 px-24 bg-neutral-10">
                 <img src={neo4jIcon} alt="Neo4j Logo" className="mx-auto mt-4 h-14" />
 


### PR DESCRIPTION
# Description

bg-palette-neutral-bg-default is no longer dark enough to contrast with the SVG background image meaning it was no longer visible.

Using the value of bg-neutral-30 instead will ensure it correctly contrasts and that it won't be inadvertently broken in the future.

Before:
![image](https://github.com/neo4j/graphql-toolbox/assets/28074382/815ef874-5fda-4211-8766-cf9fe761f1ec)

After:
![image](https://github.com/neo4j/graphql-toolbox/assets/28074382/9f96f2f1-72a9-40de-a7a7-67ed2d3705d4)

## Complexity

Low