### PR TITLE
Fix: use nested dependency version of @codemirror/commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "author": "Neo4j",
     "dependencies": {
         "@codemirror/autocomplete": "6.18.4",
-        "@codemirror/commands": "6.8.0",
         "@codemirror/lang-javascript": "6.2.2",
         "@codemirror/language": "6.10.8",
         "@dnd-kit/core": "6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,18 +495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/commands@npm:6.8.0":
-  version: 6.8.0
-  resolution: "@codemirror/commands@npm:6.8.0"
-  dependencies:
-    "@codemirror/language": "npm:^6.0.0"
-    "@codemirror/state": "npm:^6.4.0"
-    "@codemirror/view": "npm:^6.27.0"
-    "@lezer/common": "npm:^1.1.0"
-  checksum: 10c0/689f85a305f96fbe43df888c901411aefc1b937cfc8217f74d8d4d36d8bb343c5a7eae4f153391749d5fd9e49001338e39b898ce39de837d63bc83e2a6d8180d
-  languageName: node
-  linkType: hard
-
 "@codemirror/commands@npm:^6.0.0, @codemirror/commands@npm:^6.2.1":
   version: 6.3.3
   resolution: "@codemirror/commands@npm:6.3.3"
@@ -599,17 +587,6 @@ __metadata:
     style-mod: "npm:^4.1.0"
     w3c-keyname: "npm:^2.2.4"
   checksum: 10c0/4120f7953b16acd1de2d8bbf34fd289537d359b8810bb3038c62926a4ee8e0952e1d8a02d86bd0f3fa1ec80ae976f68df2a52cd0985ccfc5a48dbd2b78518b23
-  languageName: node
-  linkType: hard
-
-"@codemirror/view@npm:^6.27.0":
-  version: 6.33.0
-  resolution: "@codemirror/view@npm:6.33.0"
-  dependencies:
-    "@codemirror/state": "npm:^6.4.0"
-    style-mod: "npm:^4.1.0"
-    w3c-keyname: "npm:^2.2.4"
-  checksum: 10c0/d5811048d84ff4682354ac6e59e42ea008e5a425746ecf7c6dca2f6df675b548c25e339040f1da038b318a306cbd90fb279f15b4f694fadc721f0d8d31a68ff8
   languageName: node
   linkType: hard
 
@@ -2009,7 +1986,6 @@ __metadata:
   resolution: "@neo4j/graphql-toolbox@workspace:."
   dependencies:
     "@codemirror/autocomplete": "npm:6.18.4"
-    "@codemirror/commands": "npm:6.8.0"
     "@codemirror/lang-javascript": "npm:6.2.2"
     "@codemirror/language": "npm:6.10.8"
     "@dnd-kit/core": "npm:6.3.1"


### PR DESCRIPTION
# Description

Having this listed in our own dependencies was causing a dependency version mismatch where we have 6.8.0 but our dependencies need an earlier version of 6.3.3

```
@neo4j/graphql-toolbox@1.0.0
├── @codemirror/commands@6.8.0
├─┬ @neo4j-ndl/react@2.16.28
│ └─┬ @neo4j-cypher/react-codemirror@1.0.3
│   └─┬ @neo4j-cypher/codemirror@1.0.2
│     └── @codemirror/commands@6.3.3
└─┬ codemirror@6.0.1
  └── @codemirror/commands@6.3.3
```

## Complexity

Low