### PR TITLE
feat: adds custom indentation keybindings for tabbing and newlines

### DIFF
--- a/src/modules/EditorView/QueryEditor.tsx
+++ b/src/modules/EditorView/QueryEditor.tsx
@@ -26,7 +26,7 @@ import {
     closeBracketsKeymap,
     completionKeymap,
 } from "@codemirror/autocomplete";
-import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { bracketMatching, foldGutter, foldKeymap, indentOnInput } from "@codemirror/language";
 import { lintGutter, lintKeymap } from "@codemirror/lint";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
@@ -48,6 +48,7 @@ import { EDITOR_QUERY_INPUT } from "../../constants";
 import { AppSettingsContext } from "../../contexts/appsettings";
 import { Theme, ThemeContext } from "../../contexts/theme";
 import { useStore } from "../../store";
+import { customKeybindings } from "./customKeybindings";
 import { formatCode, handleEditorDisableState, ParserOptions } from "./utils";
 
 export interface Props {
@@ -98,7 +99,7 @@ export const QueryEditor = ({ loading, onSubmit, schema }: Props) => {
         highlightSelectionMatches(),
         EditorView.lineWrapping,
         keymap.of([
-            indentWithTab,
+            ...customKeybindings,
             ...closeBracketsKeymap,
             ...defaultKeymap,
             ...searchKeymap,

--- a/src/modules/EditorView/customKeybindings.ts
+++ b/src/modules/EditorView/customKeybindings.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EditorSelection } from "@codemirror/state";
+import type { EditorView, KeyBinding } from "@codemirror/view";
+
+const indentation = "  "; // Two spaces
+
+export const customKeybindings: readonly KeyBinding[] = [
+    {
+        key: "Tab",
+        run: (view) => {
+            const transaction = view.state.changeByRange((range) => ({
+                changes: { from: range.from, insert: indentation },
+                range: EditorSelection.cursor(range.from + 2), // Move cursor after tab
+            }));
+            view.dispatch(transaction);
+            return true; // Prevent default behavior
+        },
+    },
+    {
+        key: "Enter",
+        run: (view: EditorView) => {
+            const { state } = view;
+            const { from } = state.selection.main;
+            const line = state.doc.lineAt(from);
+            const beforeCursor = line.text.slice(0, from - line.from).trim();
+            const afterCursor = line.text.slice(from - line.from).trim();
+
+            const indent = line.text.match(/^\s*/)?.[0] || "";
+            let insertText = "\n";
+
+            if (beforeCursor.endsWith("{") && afterCursor === "}") {
+                insertText += indent + `${indentation}\n${indent}`;
+            } else if (beforeCursor.endsWith("{")) {
+                insertText += indent + indentation;
+            } else {
+                insertText += indent;
+            }
+
+            const transaction = state.update({
+                changes: { from, to: from, insert: insertText },
+                selection: EditorSelection.cursor(
+                    from + insertText.length - (afterCursor === "}" ? indent.length + 1 : 0)
+                ),
+            });
+
+            view.dispatch(transaction);
+            return true; // Prevent default behavior
+        },
+    },
+];

--- a/src/modules/SchemaView/SchemaEditor.tsx
+++ b/src/modules/SchemaView/SchemaEditor.tsx
@@ -26,7 +26,7 @@ import {
     closeBracketsKeymap,
     completionKeymap,
 } from "@codemirror/autocomplete";
-import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { bracketMatching, foldGutter, foldKeymap, indentOnInput, syntaxTree } from "@codemirror/language";
 import type { Diagnostic } from "@codemirror/lint";
 import { linter, lintGutter, lintKeymap } from "@codemirror/lint";
@@ -44,6 +44,7 @@ import { DEFAULT_TYPE_DEFS, SCHEMA_EDITOR_INPUT } from "../../constants";
 import { AppSettingsContext } from "../../contexts/appsettings";
 import { Theme, ThemeContext } from "../../contexts/theme";
 import { useStore } from "../../store";
+import { customKeybindings } from "../EditorView/customKeybindings";
 import { handleEditorDisableState } from "../EditorView/utils";
 import { getSchemaForLintAndAutocompletion, getUnsupportedDirective } from "./utils";
 
@@ -111,7 +112,7 @@ export const SchemaEditor = ({
         highlightSelectionMatches(),
         EditorView.lineWrapping,
         keymap.of([
-            indentWithTab,
+            ...customKeybindings,
             ...closeBracketsKeymap,
             ...defaultKeymap,
             ...searchKeymap,


### PR DESCRIPTION
# Description

This PR adds custom indentation keybinding:

- Pressing tab will enter indentation at the cursor
- Entering a new line will retain indentation
- Entering a new line inside curly braces `{}` will create a new nested indentation
