### PR TITLE
fix: correct the css selection for editor background color

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
         "process": "0.11.10",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "thememirror": "2.0.1",
         "zustand": "4.5.6"
     },
     "devDependencies": {

--- a/src/modules/EditorView/QueryEditor.tsx
+++ b/src/modules/EditorView/QueryEditor.tsx
@@ -41,13 +41,14 @@ import { graphql as graphqlExtension } from "cm6-graphql";
 import type { EditorView as CodeMirrorEditorView } from "codemirror";
 import { EditorView } from "codemirror";
 import type { GraphQLSchema } from "graphql";
-import { dracula, tomorrow } from "thememirror";
 
 import { Extension, FileName } from "../../components/Filename";
 import { EDITOR_QUERY_INPUT } from "../../constants";
 import { AppSettingsContext } from "../../contexts/appsettings";
 import { Theme, ThemeContext } from "../../contexts/theme";
 import { useStore } from "../../store";
+import { dracula } from "../../theme/dracula";
+import { tomorrow } from "../../theme/tomorrow";
 import { customKeybindings } from "./customKeybindings";
 import { formatCode, handleEditorDisableState, ParserOptions } from "./utils";
 

--- a/src/modules/EditorView/ResponseEditor.tsx
+++ b/src/modules/EditorView/ResponseEditor.tsx
@@ -26,11 +26,12 @@ import { bracketMatching, foldGutter, indentOnInput } from "@codemirror/language
 import { StateEffect } from "@codemirror/state";
 import { drawSelection, dropCursor, EditorView, highlightSpecialChars, keymap, lineNumbers } from "@codemirror/view";
 import classNames from "classnames";
-import { dracula, tomorrow } from "thememirror";
 
 import type { Extension } from "../../components/Filename";
 import { FileName } from "../../components/Filename";
 import { Theme, ThemeContext } from "../../contexts/theme";
+import { dracula } from "../../theme/dracula";
+import { tomorrow } from "../../theme/tomorrow";
 import { formatCode, handleEditorDisableState, ParserOptions } from "./utils";
 
 export interface Props {

--- a/src/modules/EditorView/VariablesEditor.tsx
+++ b/src/modules/EditorView/VariablesEditor.tsx
@@ -28,12 +28,13 @@ import type { ViewUpdate } from "@codemirror/view";
 import { drawSelection, dropCursor, EditorView, highlightSpecialChars, keymap, lineNumbers } from "@codemirror/view";
 import { Button } from "@neo4j-ndl/react";
 import classNames from "classnames";
-import { dracula, tomorrow } from "thememirror";
 
 import type { Extension } from "../../components/Filename";
 import { FileName } from "../../components/Filename";
 import { Theme, ThemeContext } from "../../contexts/theme";
 import { useStore } from "../../store";
+import { dracula } from "../../theme/dracula";
+import { tomorrow } from "../../theme/tomorrow";
 import { formatCode, handleEditorDisableState, ParserOptions } from "./utils";
 
 export interface Props {

--- a/src/modules/SchemaView/SchemaEditor.tsx
+++ b/src/modules/SchemaView/SchemaEditor.tsx
@@ -37,13 +37,14 @@ import { Button, IconButton, Tip } from "@neo4j-ndl/react";
 import { StarIconOutline } from "@neo4j-ndl/react/icons";
 import classNames from "classnames";
 import { graphql } from "cm6-graphql";
-import { dracula, tomorrow } from "thememirror";
 
 import { Extension, FileName } from "../../components/Filename";
 import { DEFAULT_TYPE_DEFS, SCHEMA_EDITOR_INPUT } from "../../constants";
 import { AppSettingsContext } from "../../contexts/appsettings";
 import { Theme, ThemeContext } from "../../contexts/theme";
 import { useStore } from "../../store";
+import { dracula } from "../../theme/dracula";
+import { tomorrow } from "../../theme/tomorrow";
 import { customKeybindings } from "../EditorView/customKeybindings";
 import { handleEditorDisableState } from "../EditorView/utils";
 import { getSchemaForLintAndAutocompletion, getUnsupportedDirective } from "./utils";

--- a/src/theme/create-theme.ts
+++ b/src/theme/create-theme.ts
@@ -1,0 +1,104 @@
+import type { TagStyle } from "@codemirror/language";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+// Original source is https://github.com/vadimdemedes/thememirror but it is no longer maintained.
+// This is a fork of the original source with some modifications.
+
+interface Options {
+    /**
+     * Theme variant. Determines which styles CodeMirror will apply by default.
+     */
+    variant: Variant;
+
+    /**
+     * Settings to customize the look of the editor, like background, gutter, selection and others.
+     */
+    settings: Settings;
+
+    /**
+     * Syntax highlighting styles.
+     */
+    styles: TagStyle[];
+}
+
+type Variant = "light" | "dark";
+
+interface Settings {
+    /**
+     * Editor background.
+     */
+    background: string;
+
+    /**
+     * Default text color.
+     */
+    foreground: string;
+
+    /**
+     * Caret color.
+     */
+    caret: string;
+
+    /**
+     * Selection background.
+     */
+    selection: string;
+
+    /**
+     * Background of highlighted lines.
+     */
+    lineHighlight: string;
+
+    /**
+     * Gutter background.
+     */
+    gutterBackground: string;
+
+    /**
+     * Text color inside gutter.
+     */
+    gutterForeground: string;
+}
+
+const createTheme = ({ variant, settings, styles }: Options): Extension => {
+    const theme = EditorView.theme(
+        {
+            "&": {
+                backgroundColor: settings.background,
+                color: settings.foreground,
+            },
+            ".cm-content": {
+                caretColor: settings.caret,
+            },
+            ".cm-cursor, .cm-dropCursor": {
+                borderLeftColor: settings.caret,
+            },
+            "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
+                {
+                    backgroundColor: settings.selection,
+                },
+            ".cm-activeLine": {
+                backgroundColor: settings.lineHighlight,
+            },
+            ".cm-gutters": {
+                backgroundColor: settings.gutterBackground,
+                color: settings.gutterForeground,
+            },
+            ".cm-activeLineGutter": {
+                backgroundColor: settings.lineHighlight,
+            },
+        },
+        {
+            dark: variant === "dark",
+        }
+    );
+
+    const highlightStyle = HighlightStyle.define(styles);
+    const extension = [theme, syntaxHighlighting(highlightStyle)];
+
+    return extension;
+};
+
+export default createTheme;

--- a/src/theme/dracula.ts
+++ b/src/theme/dracula.ts
@@ -1,0 +1,46 @@
+import { tags as t } from "@lezer/highlight";
+import createTheme from "./create-theme";
+
+// Author: Zeno Rocha
+export const dracula = createTheme({
+    variant: "dark",
+    settings: {
+        background: "#2d2f3f",
+        foreground: "#f8f8f2",
+        caret: "#f8f8f0",
+        selection: "#44475a",
+        gutterBackground: "#282a36",
+        gutterForeground: "rgb(144, 145, 148)",
+        lineHighlight: "#44475a",
+    },
+    styles: [
+        {
+            tag: t.comment,
+            color: "#6272a4",
+        },
+        {
+            tag: [t.string, t.special(t.brace)],
+            color: "#f1fa8c",
+        },
+        {
+            tag: [t.number, t.self, t.bool, t.null],
+            color: "#bd93f9",
+        },
+        {
+            tag: [t.keyword, t.operator],
+            color: "#ff79c6",
+        },
+        {
+            tag: [t.definitionKeyword, t.typeName],
+            color: "#8be9fd",
+        },
+        {
+            tag: t.definition(t.typeName),
+            color: "#f8f8f2",
+        },
+        {
+            tag: [t.className, t.definition(t.propertyName), t.function(t.variableName), t.attributeName],
+            color: "#50fa7b",
+        },
+    ],
+});

--- a/src/theme/tomorrow.ts
+++ b/src/theme/tomorrow.ts
@@ -1,0 +1,54 @@
+import { tags as t } from "@lezer/highlight";
+import createTheme from "./create-theme";
+
+// Author: Chris Kempson
+export const tomorrow = createTheme({
+    variant: "light",
+    settings: {
+        background: "#FFFFFF",
+        foreground: "#4D4D4C",
+        caret: "#AEAFAD",
+        selection: "#D6D6D6",
+        gutterBackground: "#FFFFFF",
+        gutterForeground: "#4D4D4C80",
+        lineHighlight: "#EFEFEF",
+    },
+    styles: [
+        {
+            tag: t.comment,
+            color: "#8E908C",
+        },
+        {
+            tag: [t.variableName, t.self, t.propertyName, t.attributeName, t.regexp],
+            color: "#C82829",
+        },
+        {
+            tag: [t.number, t.bool, t.null],
+            color: "#F5871F",
+        },
+        {
+            tag: [t.className, t.typeName, t.definition(t.typeName)],
+            color: "#C99E00",
+        },
+        {
+            tag: [t.string, t.special(t.brace)],
+            color: "#718C00",
+        },
+        {
+            tag: t.operator,
+            color: "#3E999F",
+        },
+        {
+            tag: [t.definition(t.propertyName), t.function(t.variableName)],
+            color: "#4271AE",
+        },
+        {
+            tag: t.keyword,
+            color: "#8959A8",
+        },
+        {
+            tag: t.derefOperator,
+            color: "#4D4D4C",
+        },
+    ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,7 +2049,6 @@ __metadata:
     style-loader: "npm:4.0.0"
     tailwindcss: "npm:3.4.17"
     terser-webpack-plugin: "npm:5.3.10"
-    thememirror: "npm:2.0.1"
     ts-jest: "npm:29.2.5"
     ts-loader: "npm:9.5.2"
     ts-node: "npm:10.9.2"
@@ -18044,17 +18043,6 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 10c0/02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
-  languageName: node
-  linkType: hard
-
-"thememirror@npm:2.0.1":
-  version: 2.0.1
-  resolution: "thememirror@npm:2.0.1"
-  peerDependencies:
-    "@codemirror/language": ^6.0.0
-    "@codemirror/state": ^6.0.0
-    "@codemirror/view": ^6.0.0
-  checksum: 10c0/ab4e7b254aaa2d5db2e6503eae4153c32fc639d30dba1a5c24a5f08f6caef39436eebca9cee25fd3c000a3f40b2a1155af8515d350f19aabb625fee663873ce3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This PR corrects the css selection for editor background color in `create-theme.ts`.

Original source is from https://github.com/vadimdemedes/thememirror but this project is no longer actively maintained and has some outstanding issues.

We bring the relevant files into this repository instead of keeping thememirror as a dependency.