### PR TITLE
Update renovate.json to ignore graphiql

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,11 @@
         "**/tests/**",
         "**/__fixtures__/**"
     ],
-    "ignoreDeps": ["neo4j"],
+    "ignoreDeps": [
+        "neo4j",
+        "@graphiql/plugin-doc-explorer",
+        "@​graphiql/react"
+    ],
     "packageRules": [
         {
             "matchPackageNames": ["@neo4j/graphql-toolbox"],


### PR DESCRIPTION
Adds the graphiql packages to ignoreDeps in the renovate configuration.