### PR TITLE
Always install packages instead of conditionally installing

### DIFF
--- a/.github/actions/reusable-setup/action.yml
+++ b/.github/actions/reusable-setup/action.yml
@@ -1,9 +1,6 @@
 name: 'Reusable Setup'
 description: 'Install node, pnpm and local node packages'
-inputs:
-  install-packages:
-    description: 'Whether to run pnpm install'
-    default: 'true'
+
 runs:
   using: 'composite'
   steps:
@@ -11,7 +8,6 @@ runs:
       uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
     - name: Install Packages
-      if: ${{ inputs.install-packages == 'true' }}
       shell: bash
       run: pnpm install
 

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/reusable-setup/
-        with:
-          install-packages: 'false'
 
       - name: Install markdownlint
         run: npm install -g markdownlint-cli

--- a/.github/workflows/reusable-codeql-analysis.yml
+++ b/.github/workflows/reusable-codeql-analysis.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/reusable-setup/
-        with:
-          install-packages: 'false'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3
         with:

--- a/.github/workflows/toolbox-publish.yml
+++ b/.github/workflows/toolbox-publish.yml
@@ -44,8 +44,6 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/reusable-setup/
-        with:
-          install-packages: 'false'
 
       - name: Publish the Toolbox to surge.sh
         run: |

--- a/.github/workflows/toolbox-teardown.yml
+++ b/.github/workflows/toolbox-teardown.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/reusable-setup/
-        with:
-          install-packages: 'false'
 
       - name: Teardown graphql-toolbox
         run: |


### PR DESCRIPTION
# Description

The caching in actions/setup-node relies on packages being installed and when they haven't been installed the workflow fails in CI, so we'll just go ahead and always install so the CI doesn't fail.

## Complexity

Low
