### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
         "**/tests/**",
         "**/__fixtures__/**"
     ],
-    "ignoreDeps": ["neo4j", "@graphiql/plugin-doc-explorer", "@​graphiql/react"],
+    "ignoreDeps": ["neo4j", "@graphiql/plugin-doc-explorer", "@graphiql/react"],
     "packageRules": [
         {
             "matchDatasources": ["npm"],
@@ -29,7 +29,7 @@
         },
         {
             "extends": [":pinOnlyDevDependencies"],
-            "matchPackageNames": ["*", "!@neo4j/graphql-toolbox"]
+            "matchPackageNames": ["!@neo4j/graphql-toolbox"]
         },
         {
             "groupName": "neo4j-ndl",


### PR DESCRIPTION
Closes #1226.

- Remove "*" from packageRules[2].matchPackageNames. Renovate rejects mixing * with other patterns. The remaining negative pattern "!@neo4j/graphql-toolbox" already matches all other packages.
- Fix @graphiql/react in ignoreDeps, which contained a zero-width space and never matched the real package.